### PR TITLE
Hotfix: Increase max line width of the email subject to avoid violating email messages format

### DIFF
--- a/src/elarm_mailer_email.erl
+++ b/src/elarm_mailer_email.erl
@@ -18,4 +18,8 @@ flatten(From, To, Subject, MessageText) ->
                    "To: ", To, "\r\n", "\r\n", MessageText]).
 
 subject(#alarm{alarm_id = AlarmId, src = AlarmSrc}) ->
-    io_lib:format("Alarm! ~p : ~p", [AlarmId, AlarmSrc]).
+    % Using 1000p in order to avoid linebreaks for long alarm messages
+    % Linebreaks in the email message violate format of email messages
+    % And are causing gen_smtp failures
+    % Please also refer related RFC http://www.faqs.org/rfcs/rfc2822.html
+    io_lib:format("Alarm! ~1000p : ~1000p", [AlarmId, AlarmSrc]).


### PR DESCRIPTION
The problem is in the following operation: `io_lib:format("Alarm! ~p : ~p", [AlarmId, AlarmSrc]).`
E.g. the `~p` formatted would insert linebreaks into long lines (by default the long line is every line longer than 80 chars), read also doc here: http://erlang.org/doc/man/io.html#exports So the problem is not that alarm id contains spaces (I've checked it does not) but the line length. E.g.

```
2> io:format("~p~n", [{iamverylongatom, "nowstringgoes here",  "nowstringgoes here",  "nowstringgoes here", "nowstringgoes here", "nowstringgoes here"}]).
{iamverylongatom,"nowstringgoes here","nowstringgoes here",
                 "nowstringgoes here","nowstringgoes here",
                 "nowstringgoes here"}
```