### PR TITLE
allow reloading config from the environment

### DIFF
--- a/src/elarm_mailer.erl
+++ b/src/elarm_mailer.erl
@@ -2,6 +2,7 @@
 -export([subscribe_to_alarm/5, subscribe_to_alarms/5]).
 -export([get_subscribed_alarms/0]).
 -export([start/0]).
+-export([reload_config/0]).
 
 -define(WORKER_SUP, elarm_mailer_sup).
 
@@ -24,3 +25,10 @@ subscribe_to_alarms(From, To, GenSmtpOptions, ElarmServer, Alarms) ->
     [ subscribe_to_alarm(From, To, GenSmtpOptions, ElarmServer, A)
       || A <-  Alarms ],
     ok.
+
+
+reload_config() ->
+    SubscriberPids = [
+        Pid || {_, Pid, _, _} <- supervisor:which_children(elarm_mailer_sup)],
+    [supervisor:terminate_child(elarm_mailer_sup, Pid) || Pid <- SubscriberPids],
+    elarm_mailer_app:subscribe_from_config().

--- a/src/elarm_mailer_app.erl
+++ b/src/elarm_mailer_app.erl
@@ -3,21 +3,24 @@
 
 %% Application callbacks
 -export([start/2, stop/1]).
+-export([subscribe_from_config/0]).
 
 %% ===================================================================
 %% Application callbacks
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
-    Env = fun(Key) -> elarm_mailer_config:get_env(Key) end,
     {ok, Sup} = elarm_mailer_sup:start_link(),
-    ok = elarm_mailer:subscribe_to_alarms
-           (Env(sender),
-            Env(recipients),
-            Env(gen_smtp_options),
-            Env(elarm_server),
-            Env(subscribed_alarms)),
+    subscribe_from_config(),
     {ok, Sup}.
+
+subscribe_from_config() ->
+    Env = fun(Key) -> elarm_mailer_config:get_env(Key) end,
+    ok = elarm_mailer:subscribe_to_alarms(Env(sender),
+        Env(recipients),
+        Env(gen_smtp_options),
+        Env(elarm_server),
+        Env(subscribed_alarms)).
 
 stop(_State) ->
     ok.


### PR DESCRIPTION
It is necessary for Wombat that we can reload the configuration from
the environment if the user changes the settings on the GUI.
The functionality is implemented in a way which kills alls subscribers
and then restarts everything from the config.